### PR TITLE
解决checkbox不能双向绑定的bug

### DIFF
--- a/src/components/checkbox/src/checkbox.vue
+++ b/src/components/checkbox/src/checkbox.vue
@@ -83,6 +83,9 @@
         watch: {
             checked(val) {
                 this.$emit('input', val);
+            },
+            value(val) {
+                this.checked = val;
             }
         },
         created() {


### PR DESCRIPTION
修复前
![](http://opj15jbpo.bkt.clouddn.com/17-6-7/6697781.jpg)

修复后
![](http://opj15jbpo.bkt.clouddn.com/17-6-7/75506484.jpg)

