### PR TITLE
webpack编译的问题

### DIFF
--- a/build/webpack.dist.common.conf.js
+++ b/build/webpack.dist.common.conf.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const os = require('os');
 const webpack = require('webpack');
 const merge = require('webpack-merge');
 const baseWebpackConfig = require('./base.conf');
@@ -14,7 +15,7 @@ module.exports = merge(baseWebpackConfig, {
         libraryTarget: 'umd'
     },
     externals: {
-        vue: 'vue'
+        vue: os.type() === 'linux' ? 'vue' : 'Vue'
     },
     plugins: [
         new webpack.BannerPlugin(pkg.name + ' v' + pkg.version + ' by YDCSS (c) ' + new Date().getFullYear() + ' Licensed ' + pkg.license),


### PR DESCRIPTION
若将 'Vue' 换成'vue'，会导致windows下编译后的文件不能正常工作，所以可以根据系统环境更改externals