### PR TITLE
notify 的时候内容并不能居中显示

### DIFF
--- a/src/styles/components/dialog.less
+++ b/src/styles/components/dialog.less
@@ -186,7 +186,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    width: 100%;
+    right: 0;
     background-color: rgba(40, 40, 40, .85);
     line-height: .28rem;
     font-size: .26rem;


### PR DESCRIPTION
div使用的是fixed定位，并且width 100%，padding 有值， 造成盒子变宽，内容居中显示靠右